### PR TITLE
Unnecessary console.log(...) in wrap.js

### DIFF
--- a/src/plugins/wrap.js
+++ b/src/plugins/wrap.js
@@ -2,7 +2,6 @@
 import { visit } from 'unist-util-visit';
 
 export default function remarkWrap() {
-  console.log('remarkWrap')
   return (tree) => {
     const sections = [];
     let currentSection = null;


### PR DESCRIPTION
console.log(...) floods in actions