### PR TITLE
Add index page, about page, and navigation

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,0 +1,15 @@
+---
+export interface Props {
+    title: string;
+    subtitle: string;
+}
+
+const { title, subtitle } = Astro.props;
+---
+
+<header class="blog-header">
+    <h1>{title}</h1>
+    <p class="subtitle">
+      {subtitle}
+    </p>
+</header>

--- a/src/components/NavBar.astro
+++ b/src/components/NavBar.astro
@@ -1,0 +1,4 @@
+<nav>
+    <a href="/">Blog</a>
+    <a href="/about">About</a>
+</nav>

--- a/src/components/PostHeader.astro
+++ b/src/components/PostHeader.astro
@@ -4,7 +4,7 @@ export interface Props {
     date: Date;
 }
 
-const { title, date} = Astro.props;
+const { title, date } = Astro.props;
 
 const formattedDate = date.toLocaleDateString("en-US", {
     year: "numeric",

--- a/src/content/about.md
+++ b/src/content/about.md
@@ -1,0 +1,24 @@
+## About Me
+
+<span class="newthought">Breaking things is my zen</span> — give me a web / crypto / reverse challenge and I'll disappear for hours. There's something addictive about that moment when everything clicks and the system gives up its secrets.
+
+I'm steadily climbing the CTFtime rankings, though I'll admit I'm better at solving challenges than leading teams.
+
+## What I Do
+
+**Cryptography** — PQC, lattice attacks (LLL), SageMath mostly.
+
+**Reverse Engineering** — Compiled binaries (Rust, Go, C/C++, Objective-C), interpreted languages (Python, Java, C#), malware analysis.
+
+**Web Security** — Application security testing, vulnerability research.
+
+**Java Internals** — Deobfuscators, classloading mechanics, JVM internals, JNI/JVMTI interfaces, bytecode analysis.
+
+**Security Research** — Vulnerability discovery, exploit development, writing papers with LaTeX.
+
+## Let's Connect
+
+I’m always open to technical discussions, collaborations, or interesting puzzles.
+
+**GitHub:** [SneakyF0xy](https://github.com/sneakyf0xy)  
+**Telegram:** [@OxFFCAFEBABE](https://t.me/OxFFCAFEBABE)

--- a/src/content/about.md
+++ b/src/content/about.md
@@ -1,20 +1,29 @@
+<!-- Since we got our header outside markdown we ignore the rule -->
+<!-- markdownlint-disable-next-line MD041 -->
 ## About Me
 
-<span class="newthought">Breaking things is my zen</span> — give me a web / crypto / reverse challenge and I'll disappear for hours. There's something addictive about that moment when everything clicks and the system gives up its secrets.
+<span class="newthought">Breaking things is my zen</span>
+— give me a web / crypto / reverse challenge and I'll disappear for hours.
+There's something addictive about that moment when
+everything clicks and the system gives up its secrets.
 
-I'm steadily climbing the CTFtime rankings, though I'll admit I'm better at solving challenges than leading teams.
+I'm steadily climbing the CTFtime rankings, though
+I'll admit I'm better at solving challenges than leading teams.
 
 ## What I Do
 
 **Cryptography** — PQC, lattice attacks (LLL), SageMath mostly.
 
-**Reverse Engineering** — Compiled binaries (Rust, Go, C/C++, Objective-C), interpreted languages (Python, Java, C#), malware analysis.
+**Reverse Engineering** — Compiled binaries (Rust, Go, C/C++, Objective-C),
+interpreted languages (Python, Java, C#), malware analysis.
 
 **Web Security** — Application security testing, vulnerability research.
 
-**Java Internals** — Deobfuscators, classloading mechanics, JVM internals, JNI/JVMTI interfaces, bytecode analysis.
+**Java Internals** — Deobfuscators, classloading mechanics, JVM internals,
+JNI/JVMTI interfaces, bytecode analysis.
 
-**Security Research** — Vulnerability discovery, exploit development, writing papers with LaTeX.
+**Security Research** — Vulnerability discovery, exploit development,
+writing papers with LaTeX.
 
 ## Let's Connect
 

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -18,7 +18,7 @@ const {
 } = Astro.props;
 
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
-const fullTitle = `${title} | ${SITE.title}`;
+const fullTitle = `${title}`;
 ---
 
 <!DOCTYPE html>

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -3,6 +3,7 @@ import { getCollection, render } from 'astro:content';
 import Layout from '@/layouts/Layout.astro';
 import PostHeader from '@/components/PostHeader.astro';
 import TagList from '@/components/TagList.astro';
+import NavBar from '@/components/NavBar.astro';
 import '@/styles/sneaky.css';
 
 export async function getStaticPaths() {
@@ -36,6 +37,7 @@ const structuredData = {
   structuredData={structuredData}
 >
   <main class="blog-post-container">
+    <NavBar/>
     <article class="blog-post">
       <PostHeader
         title={entry.data.title}

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,0 +1,17 @@
+---
+import Layout from '@/layouts/Layout.astro';
+import NavBar from '@/components/NavBar.astro';
+import Header from '@/components/Header.astro';
+import { Content } from '@/content/about.md';
+import '@/styles/sneaky.css';
+
+const title =  "SneakyFoxy - CTF Player & Security Researcher"
+const description = "CTF player, cryptography researcher, reverse engineer"
+---
+
+<Layout title={title} description={description}>
+    <NavBar/>
+    <Header title="Hi, I'm SneakyFoxy" 
+			subtitle="CTF player, Security Researcher"/>
+    <Content />
+</Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,16 +1,55 @@
 ---
+import Layout from '@/layouts/Layout.astro';
+import NavBar from '@/components/NavBar.astro';
+import Header from '@/components/Header.astro';
+import { getCollection } from 'astro:content';
+import '@/styles/sneaky.css';
 
+const posts = await getCollection('blog');
+const sortedPosts = posts.sort((a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime());
 ---
 
-<html lang="en">
-	<head>
-		<meta charset="utf-8" />
-		<link rel="icon" type="image/svg+xml" href="/favicon.png" />
-		<meta name="viewport" content="width=device-width" />
-		<meta name="generator" content={Astro.generator} />
-		<title>Astro</title>
-	</head>
-	<body>
-		<h1>Astro</h1>
-	</body>
-</html>
+<Layout title="Blog - SneakyFoxy" description="Technical writeups, research findings, and CTF solutions by SneakyFoxy">
+  <main class="blog-container">
+	<NavBar/>
+	<Header title="Blog" 
+			subtitle="Technical writeups, research findings, and interesting problems I encounter."/>
+
+    <div class="posts-list">
+      {sortedPosts.map(post => (
+        <div class="post-item">
+          <h2 class="post-title">
+            <a href={`/${post.id}/`}>{post.data.title}</a>
+          </h2>
+          
+          <div class="post-meta">
+            <time datetime={post.data.date.toISOString()}>
+              {post.data.date.toLocaleDateString('en-US', {
+                year: 'numeric',
+                month: 'long',
+                day: 'numeric'
+              })}
+            </time>
+            {post.data.tags && (
+              <div class="tags-classic">
+                {post.data.tags.map(tag => (
+                  <span class="tag">{tag}</span>
+                ))}
+              </div>
+            )}
+          </div>
+          
+          {post.data.description && (
+            <p class="post-excerpt">{post.data.description}</p>
+          )}
+        </div>
+      ))}
+    </div>
+
+    {sortedPosts.length === 0 && (
+      <div class="empty-state">
+        <p>No posts yet, but some interesting writeups are coming soon...</p>
+      </div>
+    )}
+  </main>
+</Layout>

--- a/src/styles/sneaky.css
+++ b/src/styles/sneaky.css
@@ -262,12 +262,55 @@ th {
     }
 }
 
+/* Navigation bar */
+nav {
+    margin-bottom: 2rem;
+}
+
+nav a {
+    margin-right: 1rem;
+    text-decoration: none;
+}
+
+.nav-current {
+    font-weight: bold;
+}
+
+/* Blog posts */
+.blog-header {
+    padding-top: 5rem;
+
+    @media (width <= 480px) {
+        padding-top: 2rem;
+    }
+}
+
+.post-item {
+    margin-bottom: 5rem;
+}
+  
+.post-item:last-child {
+    margin-bottom: 0;
+}
+
+.posts-list {
+    padding-top: 5rem;
+
+    @media (width <= 480px) {
+        padding-top: 2rem;
+    }
+}
+
 /* Links */
 a:link,
 a:visited {
     color: inherit;
     text-underline-offset: 0.1em;
     text-decoration-thickness: 0.05em;
+}
+
+nav a:hover {
+    text-decoration: underline;
 }
 
 /* Sidenotes, margin notes, figures, captions */


### PR DESCRIPTION
- Add main blog listing page at /
- Add about page at /about/ with personal info
- Add simple navigation between Blog/About
- Clean typography following Tufte CSS principles
- Proper meta titles and descriptions for SEO
- Responsive design with good spacing
- Support for post tags and dates
- Dark theme compatible